### PR TITLE
Fixes for chrome, header links to github page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,9 @@
     <link href="https://fonts.googleapis.com/css?family=Merriweather" rel="stylesheet">
 </head>
 <body>
-<h1 align="center" style="font-family: 'Merriweather', serif">headlinr</h1>
+<h1 align="center" style="font-family: 'Merriweather', serif">
+    <a href="https://github.com/dgarrick/headliner" style="color:black">headlinr</a>
+</h1>
 <script src="d3.v3.min.js"></script>
 <script>
 
@@ -64,7 +66,7 @@
             var svg = d3.select("body").append("svg")
                 .attr("width", width)
                 .attr("height", height)
-                ;
+                .append("g");
 
             console.log(nodes);
 


### PR DESCRIPTION
Chrome doesn't support SVG 2.0, but only 1.1. Thankfully, to get transforms working it's relatively simple: just put everything below the canvas into a single `g` and do the transforms on that.