### PR TITLE
Adding "watch" to stopwords

### DIFF
--- a/src/resources/stopwords
+++ b/src/resources/stopwords
@@ -151,3 +151,4 @@ wasn
 weren
 won
 wouldn
+watch


### PR DESCRIPTION
Currently "watch" articles all get lumped together, even though "watch" isn't the useful word, it's just describing the fact that there's a video attached to the article.